### PR TITLE
Fix compile time warnings

### DIFF
--- a/CampaignKitReferenceApp.xcodeproj/project.pbxproj
+++ b/CampaignKitReferenceApp.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Radius Networks, Inc. (2Z2S6NCD7P)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CampaignKitReferenceApp/CampaignKitReferenceApp-Prefix.pch";
@@ -469,6 +470,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_IDENTITY = "iPhone Distribution: Radius Networks, Inc. (2Z2S6NCD7P)";
+				DEBUG_INFORMATION_FORMAT = dwarf;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)";
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "CampaignKitReferenceApp/CampaignKitReferenceApp-Prefix.pch";

--- a/CampaignKitReferenceApp/DealsViewController.m
+++ b/CampaignKitReferenceApp/DealsViewController.m
@@ -48,7 +48,7 @@
 -(void) copyCampaigns
 {
     AppDelegate *appDelegate = (AppDelegate*)([[UIApplication sharedApplication] delegate]);
-    campaigns = [appDelegate.campaignKitManager.campaigns mutableCopy];
+    campaigns = [appDelegate.campaignKitManager.foundCampaigns mutableCopy];
 }
 
 - (void)viewWillAppear:(BOOL)animated


### PR DESCRIPTION
Fix the compile time warnings:

- [ ] Missing debug symbols warning (per #3)
- [ ] Deprecated `campaigns` method